### PR TITLE
Fix for keys that are of the type list.

### DIFF
--- a/mredu/simul.py
+++ b/mredu/simul.py
@@ -70,7 +70,8 @@ def process_shuffle_sort(in_seq):
     :param in_seq: (k, v) pairs from mapper application
     :return: shuffle-sorted (k, [v, v, v...]) pairs to be used for reduce
     """
-    grp = groupby(lambda t: t[0], in_seq)
+    # if t[0] is a list needs to be casted as a tuple because lists can't be hash keys in python.
+    grp = groupby(lambda t: (tuple(t[0]) if type(t[0]) is list else t[0]), in_seq)
     for k, vs in grp.items():
         yield((k, [v[1] for v in vs]))
 


### PR DESCRIPTION
In the function process_shuffle_sort if the key is a list it breaks when
doing the groupby because internally it uses a hash and a list can't be
a hash key in python.

POC:

```
from mredu import simul

data = [ 
        (['a', 0], 1), (['a', 1], 1), (['a', 3], 1), (['a', 3], 1), 
        (['b', 0], 1), (['b', 1], 1), (['b', 6], 1), (['b', 7], 1), 
        (['c', 1], 1), (['c', 3], 1), (['c', 3], 1), (['c', 4], 1)
        ]

print(list(simul.process_shuffle_sort(data)))
```

result:

`
Traceback (most recent call last):                                                              
  File "bug_poc.py", line 7, in <module>                                                        
    print(list(simul.process_shuffle_sort(data)));                                              
  File "/Users/jp/Documents/utad/mredu/mredu/mredu/simul.py", line 73, in process_shuffle_sort  
    grp = groupby(lambda t: t[0], in_seq)                                                       
  File "/Users/jp/anaconda3/lib/python3.6/site-packages/toolz/itertoolz.py", line 93, in groupby
    d[key(item)](item)                                                                          
TypeError: unhashable type: 'list'
`